### PR TITLE
Adapt to specs 202305

### DIFF
--- a/app/controllers/scimaenaga/application_controller.rb
+++ b/app/controllers/scimaenaga/application_controller.rb
@@ -6,6 +6,7 @@ module Scimaenaga
     include ExceptionHandler
     include Response
 
+    around_action :set_locale
     before_action :authorize_request
 
     private
@@ -67,6 +68,13 @@ module Scimaenaga
           end
           nil
         end
+      end
+
+      def set_locale
+        I18n.locale = :en
+        yield
+      ensure
+        I18n.locale = I18n.default_locale
       end
   end
 end

--- a/app/libraries/scim_patch_operation.rb
+++ b/app/libraries/scim_patch_operation.rb
@@ -47,7 +47,17 @@ class ScimPatchOperation
       filter_string = path_str.slice!(/\[(.+?)\]/, 0)&.slice(/\[(.+?)\]/, 1)
 
       # path_elements: ['emails', 'value']
-      path_elements = path_str.split('.')
+      attributes = Scimaenaga.config.mutable_user_attributes_schema.keys.map(&:to_s)
+      first_element = attributes.find { |attr| path_str.start_with?(attr) }
+      path_elements =
+        if path_str == first_element
+          [first_element]
+        elsif first_element
+          elements_after_first = path_str.slice((first_element.length + 1)..-1).split('.')
+          [first_element] + elements_after_first
+        else
+          path_str.split('.') # This should not pass if the config is correctly defined.
+        end
 
       # filter_elements: ['type', 'eq', '"work"']
       filter_elements = filter_string&.split(' ')


### PR DESCRIPTION
## 対応事項

### SCIM のリクエストで使用する言語は `:en` を明示的に指定する。 ac3dd6a5a21156b3d408bcb8471b0606aa61f91a

`:en` でのメッセージに依存する箇所があり、指定しないとアプリ側の `default_locale` が用いられるため、処理が完了するまで `:en` に切り替える。

### PATCH のリクエストで拡張スキーマの属性の指定にも対応した。 ccbf90c8b574c158985c09bb727988f84b3bc892

PATCH での更新時、拡張スキーマへの属性の更新があった場合は以下のようにが指定される。

```
"path": "urn:ietf:params:scim:schemas:extension:yourdomain:2.0:User.customAttribute"
```

しかし、修正前だと `.split('.')` と指定しているのみのため、`2` と `0` の間でも分割されてしまう。
そのため、1階層目のみは config ファイルに記載されている attribute を拾うようにした。
