### PR TITLE
Ensure Consistency for Concurrent PATCH Requests on Group Members

### DIFF
--- a/app/libraries/scim_patch_operation_group.rb
+++ b/app/libraries/scim_patch_operation_group.rb
@@ -19,6 +19,7 @@ class ScimPatchOperationGroup < ScimPatchOperation
   private
 
     def save_members(model)
+      model.lock!
       current_member_ids = model.public_send(member_relation_attribute).map(&:to_s)
 
       case @op


### PR DESCRIPTION
同時にリクエストがあると、リクエストが後勝ちするケースがあるため、排他制御をかけるようにした。

検証は以下で行った。
https://github.com/ingage/activefollow-rails/issues/20327
