### PR TITLE
Implement Exclusive Locking at the Start of Transactions

### DIFF
--- a/app/libraries/scim_patch.rb
+++ b/app/libraries/scim_patch.rb
@@ -26,7 +26,7 @@ class ScimPatch
   end
 
   def save(model)
-    model.transaction do
+    model.with_lock do
       @operations.each do |operation|
         operation.save(model)
       end

--- a/app/libraries/scim_patch_operation_group.rb
+++ b/app/libraries/scim_patch_operation_group.rb
@@ -19,7 +19,6 @@ class ScimPatchOperationGroup < ScimPatchOperation
   private
 
     def save_members(model)
-      model.lock!
       current_member_ids = model.public_send(member_relation_attribute).map(&:to_s)
 
       case @op


### PR DESCRIPTION
#4 の考慮漏れ。

パラメータが複数あった場合、例えばグループ名の後にメンバーの追加があると、`model.lock!` で以下のエラーが発生する。

```
Locking a record with unpersisted changes is not supported. Use `save` to persist the changes, or `reload` to discard them explicitly.
```

そのため、トランザクション開始時にロックをかけるようにした。
動作検証は以下と同様に行い、問題なし。
https://github.com/ingage/activefollow-rails/issues/20327